### PR TITLE
Route end behavior

### DIFF
--- a/src/lib/routing/response.ts
+++ b/src/lib/routing/response.ts
@@ -27,10 +27,12 @@ export default class EResponse {
   }
 
   // For better express support
-  end(body: BodyInit) {
+  end(body: BodyInit = null) {
     if (this.hasEnded) return;
 
-    this.send(body);
+    if(body != null) {
+      this.send(body);
+    }
     this._hasEnded = true;
   }
 

--- a/src/lib/routing/router.ts
+++ b/src/lib/routing/router.ts
@@ -29,10 +29,7 @@ export class Router {
       const res = new EResponse(this.config);
 
       await this.runMiddlewares(req, res);
-
-      if (!res.hasEnded) {
-        await this.runRoutes(req, res);
-      }
+      await this.runRoutes(req, res);
 
       return serializeResponse(res);
     } catch (e) {
@@ -42,6 +39,9 @@ export class Router {
 
   private async runMiddlewares(req: ERequest, res: EResponse): Promise<any> {
     for (let m of this.middlewares) {
+      if (res.hasEnded) {
+        break;
+      }
       if (m.check(req)) {
         await m.run(req, res);
       }
@@ -49,10 +49,13 @@ export class Router {
   }
 
   private async runRoutes(req: ERequest, res: EResponse): Promise<any> {
-    const matchedRoute = this.routes.find((route): boolean => route.check(req));
-
-    if (matchedRoute) {
-      await matchedRoute.run(req, res);
+    for (let r of this.routes) {
+      if (res.hasEnded) {
+        break;
+      }
+      if (r.check(req)) {
+        await r.run(req, res);
+      }
     }
   }
 


### PR DESCRIPTION
This is a PR to address the following things to make Expressly behave more closely to Express (and be less surprising):

* As in Express, a route handler should fall through to the next one (in the same way that middleware does) until `res.end()` is called.

* It should also be possible to call `res.end()` with no params to end the response without affecting the stream already sent.