### PR TITLE
update live reloading documentation to use the built-in watch mode of the fastly cli

### DIFF
--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -53,9 +53,8 @@ This will start your service on [http://localhost:7676](http://localhost:7676).
 
 ### Live reloading
 
-You can use a tool called [`nodemon`](https://www.npmjs.com/package/nodemon) to automatically reload your app when you make a change in your local development environment.
+You can use the Fastly CLI to automatically reload your app when you make a change in your local development environment.
 
 ```shell
-npx nodemon --exec \
-  "npm run build && fastly compute serve --skip-build"
+fastly compute serve --watch"
 ```


### PR DESCRIPTION
The watch flag will cause the cli to watch for file changes, then rebuild project and restart local server