### PR TITLE
update cookie.expires type to Date

### DIFF
--- a/src/lib/routing/index.d.ts
+++ b/src/lib/routing/index.d.ts
@@ -13,7 +13,7 @@ export type EConfig = {
 export type CookieOptions = {
   domain?: string;
   encode?: string;
-  expires?: string;
+  expires?: Date;
   httpOnly?: boolean;
   maxAge?: number;
   path?: string;

--- a/src/lib/routing/response/index.ts
+++ b/src/lib/routing/response/index.ts
@@ -29,7 +29,7 @@ class EResponseBase {
   clearCookie(key: string, options: CookieOptions = {}): void {
     if (this.hasEnded) return;
 
-    this.cookie(key, "", { ...options, expires: "Thu, 01 Jan 1970 00:00:00 GMT" });
+    this.cookie(key, "", { ...options, expires: new Date("Thu, 01 Jan 1970 00:00:00 GMT") });
   }
 
   // Response lifecycle methods.


### PR DESCRIPTION
Fixes https://github.com/fastly/expressly/issues/11 – using the [correct type](https://github.com/jshttp/cookie#expires) for the `expires` option in `jshttp/cookie`.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.0.0--canary.12.2965155262.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @fastly/expressly@1.0.0--canary.12.2965155262.0
  # or 
  yarn add @fastly/expressly@1.0.0--canary.12.2965155262.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
