### PR TITLE
Support node engines >16

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "router"
   ],
   "engines": {
-    "node": "^16"
+    "node": ">=16.0.0"
   },
   "author": "oss@fastly.com",
   "license": "MIT",


### PR DESCRIPTION
The node version should be irrelevant anyway as this is a C@E package. This will remove the warning that is printed when using node v17 or v18.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.0.0--canary.16.3385502687.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @fastly/expressly@1.0.0--canary.16.3385502687.0
  # or 
  yarn add @fastly/expressly@1.0.0--canary.16.3385502687.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
