### PR TITLE
Fix example for setting header to use set() instead of setHeader()

### DIFF
--- a/docs/docs/middleware/what-is-middleware.md
+++ b/docs/docs/middleware/what-is-middleware.md
@@ -14,7 +14,7 @@ The example below shows how to use middleware to add a header to all requests:
 
 ```javascript
 router.use((req, res) => {
-  res.setHeader("x-powered-by", "expressly");
+  res.set("x-powered-by", "expressly");
 });
 ```
 


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.0.0--canary.19.3653536560.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @fastly/expressly@1.0.0--canary.19.3653536560.0
  # or 
  yarn add @fastly/expressly@1.0.0--canary.19.3653536560.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
