### PR TITLE
use DOCS_SERVICE_ID secret in docs publish workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -49,5 +49,5 @@ jobs:
         env:
           FASTLY_API_TOKEN: ${{ secrets.FASTLY_API_TOKEN }}
         run: |
-          curl -s -H "Fastly-Key: $FASTLY_API_TOKEN" -X POST "https://api.fastly.com/service/44O0OSuWrOWkzVek5Gg4QN/purge_all"
+          curl -s -H "Fastly-Key: $FASTLY_API_TOKEN" -X POST "https://api.fastly.com/service/${{ secrets.DOCS_SERVICE_ID }}/purge_all"
         


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.0.0--canary.20.3748435520.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @fastly/expressly@1.0.0--canary.20.3748435520.0
  # or 
  yarn add @fastly/expressly@1.0.0--canary.20.3748435520.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
