### PR TITLE
fix: Only send 204 when no response body

### DIFF
--- a/src/lib/routing/router.ts
+++ b/src/lib/routing/router.ts
@@ -220,7 +220,7 @@ export class Router {
     const response = new Response(res.body, {
       headers: res.headers,
       // Default to 200 / 204 if no status was set by middleware / route handler.
-      status: res.status ? res.status : Boolean(res.body) ? 200 : 204,
+      status: res.status ? res.status : res.body !== null && res.body !== undefined ? 200 : 204,
     });
     if (res.headers.cookies.size) {
       // Loop cookies manually to work around this issue: https://github.com/fastly/js-compute-runtime/issues/47


### PR DESCRIPTION
Creating a new `Response` with a falsy non-null body (eg. an empty string) results in an Error (`Response body is given with a null body status.`).

To recreate the issue, try `new Response(", {status: 204})` or in Expressly, call `response.end("")`.

This PR changes the body check for `null` and `undefined` specifically and return `200` otherwise. 

Spec: https://fetch.spec.whatwg.org/#response-class

```
Error while running request handler: Response constructor: Response body is given with a null body status.
Stack:
   serializeResponse@webpack: ~/node_modules/@fastly/expressly/dist/lib/routing/router.js?:205:26
   handler@webpack: ~/node_modules/@fastly/expressly/dist/lib/routing/router.js?:95:23
   async*listen/<@webpack: ~/node_modules/@fastly/expressly/dist/lib/routing/router.js?:80:69
```
