### PR TITLE
extend error with default status 500

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fastly/expressly",
-  "version": "2.0.0",
+  "version": "2.2.0",
   "description": "Express-style router for Fastly's Compute@Edge.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/lib/routing/error-middleware.ts
+++ b/src/lib/routing/error-middleware.ts
@@ -1,19 +1,28 @@
 import { EReq } from "./request";
 import { ERes } from "./response";
+import { EErr } from "./errors";
 
-export type ErrorMiddlewareCallback = (err: Error, req: EReq, res: ERes) => Promise<any>;
+export type ErrorMiddlewareCallback<
+  Err extends EErr = EErr,
+  Req extends EReq = EReq,
+  Res extends ERes = ERes,
+> = (err: Err, req: Req, res: Res) => Promise<any> | void;
 
-export class ErrorMiddleware {
+export class ErrorMiddleware<
+  Err extends EErr = EErr,
+  Req extends EReq = EReq,
+  Res extends ERes = ERes,
+>  {
   constructor(
     private matchFn: Function,
-    private callback: ErrorMiddlewareCallback
-  ) {}
+    private callback: ErrorMiddlewareCallback<Err, Req, Res>,
+  ) { }
 
-  public check(event: EReq): 0 | 404 | string[] {
+  public check(event: Req): 0 | 404 | string[] {
     return this.matchFn(event);
   }
 
-  public async run(err: Error, req: EReq, res: ERes): Promise<any> {
+  public async run(err: Err, req: Req, res: Res): Promise<any> {
     await this.callback(err, req, res);
   }
 }

--- a/src/lib/routing/errors.ts
+++ b/src/lib/routing/errors.ts
@@ -1,4 +1,12 @@
-export class ErrorNotFound extends Error {
+export class EErr extends Error {
+    public status: number = 500;
+    constructor(message?: string) {
+        super(message);
+        Object.setPrototypeOf(this, EErr.prototype);
+    }
+}
+
+export class ErrorNotFound extends EErr {
     public status: number = 404;
     constructor() {
         super("Not Found");
@@ -6,7 +14,7 @@ export class ErrorNotFound extends Error {
     }
 }
 
-export class ErrorMethodNotAllowed extends Error {
+export class ErrorMethodNotAllowed extends EErr {
     public status: number = 405;
     public allow: string = "";
 

--- a/src/lib/routing/router.ts
+++ b/src/lib/routing/router.ts
@@ -67,7 +67,6 @@ export class Router<
   /**
    * Handles preflight requests from trusted origins configured by the user when initializing a router.
    * Note that the wildcard value "*" will fail if the request is sent with credentials (see: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin#directives)
-   * @param autoCorsPreflight the object containing CORS preflight option of trustedOrigins, an array of trusted origins.
    * @returns 200 if the preflight request succeeds, 403 if it fails
    */
   private async preflightHandler(req: Req, res: Res) {

--- a/src/lib/routing/router.ts
+++ b/src/lib/routing/router.ts
@@ -1,62 +1,20 @@
 import { match } from "path-to-regexp";
-import { AutoCorsPreflightOptions, EConfig, Method } from ".";
+import { EConfig, Method } from ".";
 import { RequestHandler, RequestHandlerCallback } from "./request-handler";
 import { ErrorMiddleware, ErrorMiddlewareCallback } from "./error-middleware";
-import { ErrorNotFound, ErrorMethodNotAllowed } from "./errors";
+import { ErrorNotFound, ErrorMethodNotAllowed, EErr } from "./errors";
 import { ERequest, EReq } from "./request";
 import { EResponse, ERes } from "./response";
 
 const pathMatcherCache: Map<string, Function> = new Map();
 
-const defaultErrorHandler = (auto405) => async (err: Error, req: EReq, res: ERes) => {
-  if (err instanceof ErrorNotFound || (err instanceof ErrorMethodNotAllowed && !auto405)) {
-    return res.sendStatus(404);
-  } else if (err instanceof ErrorMethodNotAllowed) {
-    res.headers.set("Allow", err.allow);
-    return res.sendStatus(405);
-  }
-  console.error(err);
-  res.withStatus(500).json({ error: err.message });
-}
-
-/**
- * Handles preflight requests from trusted origins configured by the user when initializing a router.
- * Note that the wildcard value "*" will fail if the request is sent with credentials (see: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin#directives)
- * @param autoCorsPreflight the object containing CORS preflight option of trustedOrigins, an array of trusted origins.
- * @returns 200 if the preflight request succeeds, 403 if it fails
- */
-const preflightHandler = (autoCorsPreflight: AutoCorsPreflightOptions) => async (req: EReq, res: ERes) => {
-  if (autoCorsPreflight.trustedOrigins.length === 0) {
-    return res.sendStatus(403);
-  }
-  let originHeaderValue: string | null = null;
-  if (autoCorsPreflight.trustedOrigins.length === 1 && autoCorsPreflight.trustedOrigins[0] === "*") {
-    originHeaderValue = "*";
-  } else if (req.headers.has("origin")) {
-    const origin = req.headers.get("origin").toLowerCase();
-    if (autoCorsPreflight.trustedOrigins.some((trustedOrigin) => trustedOrigin.toLowerCase() === origin)) {
-      originHeaderValue = origin;
-    }
-  }
-  if (!originHeaderValue) {
-    return res.sendStatus(403);
-  }
-  if (req.headers.has("access-control-request-method")) {
-    res.headers.set("access-control-allow-methods", req.headers.get("access-control-request-method"));
-  }
-  if (req.headers.has("access-control-request-headers")) {
-    res.headers.set("access-control-allow-headers", req.headers.get("access-control-request-headers"));
-  }
-  res.headers.set("access-control-allow-origin", originHeaderValue);
-  return res.sendStatus(200);
-}
-
 export class Router<
-Req extends EReq = EReq,
-Res extends ERes = ERes
+  Req extends EReq = EReq,
+  Res extends ERes = ERes,
+  Err extends EErr = EErr,
 > {
-  requestHandlers: Array<RequestHandler> = [];
-  errorHandlers: Array<ErrorMiddleware> = [];
+  requestHandlers: Array<RequestHandler<Req,Res>> = [];
+  errorHandlers: Array<ErrorMiddleware<Err,Req,Res>> = [];
   config: EConfig = {
     parseCookie: true,
     auto405: true,
@@ -70,7 +28,7 @@ Res extends ERes = ERes
       ...config
     }
     if (this.config.autoCorsPreflight) {
-      this.options("*", preflightHandler(this.config.autoCorsPreflight));
+      this.options("*", this.preflightHandler);
     }
   }
 
@@ -88,69 +46,112 @@ Res extends ERes = ERes
       await this.runRequestHandlers(req as Req, res as Res);
     } catch (err) {
       // Add default error handler.
-      this.use(defaultErrorHandler(this.config.auto405));
+      this.use(this.defaultErrorHandler);
       // Run error handler stack.
       await this.runErrorHandlers(err, req as Req, res as Res);
     }
     return Router.serializeResponse(res);
   }
 
+  private async defaultErrorHandler(err: Err, req: Req, res: Res) {
+    if (err instanceof ErrorNotFound || (err instanceof ErrorMethodNotAllowed && !this.config.auto405)) {
+      return res.sendStatus(404);
+    } else if (err instanceof ErrorMethodNotAllowed) {
+      res.headers.set("Allow", err.allow);
+      return res.sendStatus(405);
+    }
+    console.error(err);
+    res.withStatus(500).json({ error: err.message });
+  }
+
+  /**
+   * Handles preflight requests from trusted origins configured by the user when initializing a router.
+   * Note that the wildcard value "*" will fail if the request is sent with credentials (see: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin#directives)
+   * @param autoCorsPreflight the object containing CORS preflight option of trustedOrigins, an array of trusted origins.
+   * @returns 200 if the preflight request succeeds, 403 if it fails
+   */
+  private async preflightHandler(req: Req, res: Res) {
+    if (this.config.autoCorsPreflight.trustedOrigins.length === 0) {
+      return res.sendStatus(403);
+    }
+    let originHeaderValue: string | null = null;
+    if (this.config.autoCorsPreflight.trustedOrigins.includes("*")) {
+      originHeaderValue = "*";
+    } else if (req.headers.has("origin")) {
+      const origin = req.headers.get("origin").toLowerCase();
+      if (this.config.autoCorsPreflight.trustedOrigins.some((trustedOrigin) => trustedOrigin.toLowerCase() === origin)) {
+        originHeaderValue = origin;
+      }
+    }
+    if (!originHeaderValue) {
+      return res.sendStatus(403);
+    }
+    if (req.headers.has("access-control-request-method")) {
+      res.headers.set("access-control-allow-methods", req.headers.get("access-control-request-method"));
+    }
+    if (req.headers.has("access-control-request-headers")) {
+      res.headers.set("access-control-allow-headers", req.headers.get("access-control-request-headers"));
+    }
+    res.headers.set("access-control-allow-origin", originHeaderValue);
+    return res.sendStatus(200);
+  }
+
   // Middleware attach point.
   public use(
-    path: string | RequestHandlerCallback<Req, Res> | ErrorMiddlewareCallback,
-    callback?: RequestHandlerCallback<Req, Res> | ErrorMiddlewareCallback
+    path: string | RequestHandlerCallback<Req, Res> | ErrorMiddlewareCallback<Err,Req,Res>,
+    callback?: RequestHandlerCallback<Req, Res> | ErrorMiddlewareCallback<Err,Req,Res>
   ): void {
     const cb = path instanceof Function ? path : callback;
     const matcher = path instanceof Function ? () => 0 : this.routeMatcher(["*"], path as string);
     if (cb.length === 3) {
       this.errorHandlers.push(
-        new ErrorMiddleware(matcher, cb as ErrorMiddlewareCallback)
+        new ErrorMiddleware(matcher, cb as ErrorMiddlewareCallback<Err,Req,Res>)
       );
     } else {
       this.requestHandlers.push(
-        new RequestHandler<Req, Res>(matcher, cb as RequestHandlerCallback<Req,Res>)
+        new RequestHandler<Req, Res>(matcher, cb as RequestHandlerCallback<Req, Res>)
       )
     }
   }
 
   // Router API.
-  public route(methods: Method[], pattern: string, callback: RequestHandlerCallback<Req,Res>): void {
+  public route(methods: Method[], pattern: string, callback: RequestHandlerCallback<Req, Res>): void {
     this.requestHandlers.push(new RequestHandler<Req, Res>(this.routeMatcher(methods.map(m => m.toUpperCase()), pattern), callback));
   }
 
-  public all(pattern: string, callback: RequestHandlerCallback<Req,Res>): void {
+  public all(pattern: string, callback: RequestHandlerCallback<Req, Res>): void {
     this.route(["*"], pattern, callback);
   }
 
-  public get(pattern: string, callback: RequestHandlerCallback<Req,Res>): void {
+  public get(pattern: string, callback: RequestHandlerCallback<Req, Res>): void {
     this.route(["GET"], pattern, callback);
   }
 
-  public post(pattern: string, callback: RequestHandlerCallback<Req,Res>): void {
+  public post(pattern: string, callback: RequestHandlerCallback<Req, Res>): void {
     this.route(["POST"], pattern, callback);
   }
 
-  public put(pattern: string, callback: RequestHandlerCallback<Req,Res>): void {
+  public put(pattern: string, callback: RequestHandlerCallback<Req, Res>): void {
     this.route(["PUT"], pattern, callback);
   }
 
-  public delete(pattern: string, callback: RequestHandlerCallback<Req,Res>): void {
+  public delete(pattern: string, callback: RequestHandlerCallback<Req, Res>): void {
     this.route(["DELETE"], pattern, callback);
   }
 
-  public head(pattern: string, callback: RequestHandlerCallback<Req,Res>): void {
+  public head(pattern: string, callback: RequestHandlerCallback<Req, Res>): void {
     this.route(["HEAD"], pattern, callback);
   }
 
-  public options(pattern: string, callback: RequestHandlerCallback<Req,Res>): void {
+  public options(pattern: string, callback: RequestHandlerCallback<Req, Res>): void {
     this.route(["OPTIONS"], pattern, callback);
   }
 
-  public patch(pattern: string, callback: RequestHandlerCallback<Req,Res>): void {
+  public patch(pattern: string, callback: RequestHandlerCallback<Req, Res>): void {
     this.route(["PATCH"], pattern, callback);
   }
 
-  public purge(pattern: string, callback: RequestHandlerCallback<Req,Res>): void {
+  public purge(pattern: string, callback: RequestHandlerCallback<Req, Res>): void {
     this.route(["PURGE"], pattern, callback);
   }
 
@@ -177,7 +178,7 @@ Res extends ERes = ERes
   }
 
   // Error handler runner.
-  private async runErrorHandlers(err: Error, req: Req, res: Res): Promise<any> {
+  private async runErrorHandlers(err: Err, req: Req, res: Res): Promise<any> {
     for (let eH of this.errorHandlers) {
       if (res.hasEnded) {
         break;

--- a/test-d/error-test-d.ts
+++ b/test-d/error-test-d.ts
@@ -1,0 +1,34 @@
+import { expectType } from 'tsd';
+import { Router } from "../dist";
+import { EReq } from "../dist/lib/routing/request";
+import { ERes } from '../dist/lib/routing/response';
+import { EErr } from "../dist/lib/routing/errors";
+
+// Default Err types
+{
+  const router = new Router();
+  router.use(async (err, _, res) => {
+    expectType<EErr>(err)
+  });
+}
+
+// Custom Req and Res types
+{
+  interface MeowErr extends EErr {
+    meow(): string
+  }
+
+  interface WoofErr extends EErr {
+    woof(): string
+  }
+
+  interface MyErr extends MeowErr, WoofErr { }
+
+  const router = new Router<EReq,ERes,MyErr>();
+  router.use(async (err, _, res) => {
+    expectType<MyErr>(err)
+    err.meow()
+    err.woof()
+  });
+
+}


### PR DESCRIPTION
Allows for extending `Error` and fixes https://github.com/fastly/expressly/issues/38, introducing default status 500.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.2.1--canary.47.6578278940.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @fastly/expressly@2.2.1--canary.47.6578278940.0
  # or 
  yarn add @fastly/expressly@2.2.1--canary.47.6578278940.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
