### PR TITLE
Implement res.on('finish', callback)

### DIFF
--- a/docs/docs/handling-data/response.md
+++ b/docs/docs/handling-data/response.md
@@ -124,9 +124,7 @@ router.get("/page", async (req, res) => {
 });
 ```
 
-## res.on()
- 
-### res.on('finish', callback)
+## res.on('finish', callback)
 
 Provides a useful listener for tidying up any post-request actions (e.g., sending logs, metrics or traces).
 

--- a/docs/docs/handling-data/response.md
+++ b/docs/docs/handling-data/response.md
@@ -124,6 +124,21 @@ router.get("/page", async (req, res) => {
 });
 ```
 
+## res.on()
+ 
+### res.on('finish', callback)
+
+Provides a useful listener for tidying up any post-request actions (e.g., sending logs, metrics or traces).
+
+> Note: The `finish` event is emitted immediately before the final response headers and body are handed off to the Fastly Compute platform, to send back to the client.
+
+```javascript
+router.use((_, res) => {
+  res.on("finish", (finalResponse) => {
+    console.log("Response sent!", finalResponse);
+  });
+});
+```
 
 ## Response headers
 

--- a/package.json
+++ b/package.json
@@ -32,16 +32,17 @@
     "@types/node": "^18.18.6",
     "auto": "^11.0.4",
     "husky": "^8.0.3",
-    "prettier": "^3.0.3",
+    "prettier": "^3.1.1",
     "pretty-quick": "^3.1.3",
-    "ts-loader": "^9.5.0",
-    "tsd": "^0.29.0",
-    "typescript": "^5.2.2"
+    "ts-loader": "^9.5.1",
+    "tsd": "^0.30.3",
+    "typescript": "^5.3.3"
   },
   "dependencies": {
     "@fastly/js-compute": "^3.7.0",
-    "cookie": "^0.5.0",
-    "core-js": "^3.33.0",
+    "cookie": "^0.6.0",
+    "mitt": "^3.0.1",
+    "core-js": "^3.35.0",
     "path-to-regexp": "^6.2.1"
   },
   "auto": {

--- a/src/lib/routing/response/index.ts
+++ b/src/lib/routing/response/index.ts
@@ -6,6 +6,8 @@ import { SurrogateKeys } from "./surrogate-keys";
 import { EHeaders } from "./headers";
 import { CookieOptions, EConfig } from "..";
 
+export type EResponseEvent = "finish";
+
 export type EResponseEvents = {
   finish: Response;
 }
@@ -44,7 +46,7 @@ export class EResponse {
     });
   }
 
-  on(event: "finish", callback: (finalResponse?: Response) => void): void {
+  on(event: EResponseEvent, callback: (finalResponse?: Response) => void): void {
     this.emitter.on(event, callback);
   }
   

--- a/src/lib/routing/response/index.ts
+++ b/src/lib/routing/response/index.ts
@@ -20,7 +20,7 @@ export class EResponse {
   surrogateKeys: SurrogateKeys = new SurrogateKeys(this.headers);
   emitter: Emitter<EResponseEvents> = mitt<EResponseEvents>();
 
-  constructor(private config: EConfig) {}
+  constructor(private config: EConfig) { }
 
   set = setFn(this);
   append = appendFn(this);
@@ -46,10 +46,10 @@ export class EResponse {
     });
   }
 
-  on(event: EResponseEvent, callback: (finalResponse?: Response) => void): void {
+  on<TEvent extends keyof EResponseEvents>(event: TEvent, callback: (param: EResponseEvents[TEvent]) => void): void {
     this.emitter.on(event, callback);
   }
-  
+
   // Response lifecycle methods.
   send(response: BodyInit | Response) {
     if (this.hasEnded) return;
@@ -138,4 +138,4 @@ export class EResponse {
   }
 }
 
-export interface ERes extends EResponse {}
+export interface ERes extends EResponse { }

--- a/src/lib/routing/response/index.ts
+++ b/src/lib/routing/response/index.ts
@@ -44,7 +44,7 @@ export class EResponse {
     });
   }
 
-  on(event: 'finish', callback: (finalResponse?: Response) => void): void {
+  on(event: "finish", callback: (finalResponse?: Response) => void): void {
     this.emitter.on(event, callback);
   }
   

--- a/src/lib/routing/response/index.ts
+++ b/src/lib/routing/response/index.ts
@@ -1,9 +1,14 @@
 import cookie from "cookie";
+import mitt, { Emitter } from "mitt";
 import { appendFn, setFn } from "../common";
 import { statusText } from "./status-codes";
 import { SurrogateKeys } from "./surrogate-keys";
 import { EHeaders } from "./headers";
 import { CookieOptions, EConfig } from "..";
+
+export type EResponseEvents = {
+  finish: Response;
+}
 
 export class EResponse {
   headers: EHeaders = new EHeaders();
@@ -11,6 +16,7 @@ export class EResponse {
   body: BodyInit = null;
   hasEnded: boolean = false;
   surrogateKeys: SurrogateKeys = new SurrogateKeys(this.headers);
+  emitter: Emitter<EResponseEvents> = mitt<EResponseEvents>();
 
   constructor(private config: EConfig) {}
 
@@ -38,6 +44,10 @@ export class EResponse {
     });
   }
 
+  on(event: 'finish', callback: (finalResponse?: Response) => void): void {
+    this.emitter.on(event, callback);
+  }
+  
   // Response lifecycle methods.
   send(response: BodyInit | Response) {
     if (this.hasEnded) return;

--- a/src/lib/routing/router.ts
+++ b/src/lib/routing/router.ts
@@ -230,6 +230,8 @@ export class Router<
       response.headers.delete("Set-Cookie");
       res.headers.cookies.forEach((c) => response.headers.append("Set-Cookie", c));
     }
+    res.emitter.emit("finish", response);
+    res.emitter.all.clear();
     return response;
   }
 }

--- a/test-d/router-test-d.ts
+++ b/test-d/router-test-d.ts
@@ -46,6 +46,9 @@ import { ERes } from '../dist/lib/routing/response';
   router.get('/', async (req, res) => {
     expectType<MyReq>(req)
     expectType<WoofRes>(res)
-    return res.send("Hello world!");
+    res.on('finish', finalResponse => {
+      expectType<Response | undefined>(finalResponse)
+    })
+    return res.send("Hello world!")
   });
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -561,10 +561,10 @@
   resolved "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz"
   integrity sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==
 
-"@tsd/typescript@~5.2.2":
-  version "5.2.2"
-  resolved "https://registry.npmjs.org/@tsd/typescript/-/typescript-5.2.2.tgz"
-  integrity sha512-VtjHPAKJqLJoHHKBDNofzvQB2+ZVxjXU/Gw6INAS9aINLQYVsxfzrQ2s84huCeYWZRTtrr7R0J7XgpZHjNwBCw==
+"@tsd/typescript@~5.3.3":
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/@tsd/typescript/-/typescript-5.3.3.tgz#bc01854b6e0e746b5f70a6b48c30c7b95b81a74e"
+  integrity sha512-CQlfzol0ldaU+ftWuG52vH29uRoKboLinLy84wS8TQOu+m+tWoaUfk4svL4ij2V8M5284KymJBlHUusKj6k34w==
 
 "@types/command-line-args@^5.0.0":
   version "5.2.0"
@@ -960,15 +960,15 @@ concat-map@0.0.1:
   resolved "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
   integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
 
-cookie@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz"
-  integrity sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==
+cookie@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.6.0.tgz#2798b04b071b0ecbff0dbb62a505a8efa4e19051"
+  integrity sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==
 
-core-js@^3.33.0:
-  version "3.33.0"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.33.0.tgz#70366dbf737134761edb017990cf5ce6c6369c40"
-  integrity sha512-HoZr92+ZjFEKar5HS6MC776gYslNOKHt75mEBKWKnPeFDpZ6nH5OeF3S6HFT1mUAUZKrzkez05VboaX8myjSuw==
+core-js@^3.35.0:
+  version "3.35.0"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.35.0.tgz#58e651688484f83c34196ca13f099574ee53d6b4"
+  integrity sha512-ntakECeqg81KqMueeGJ79Q5ZgQNR+6eaE8sxGCx62zMbAIj65q+uYvatToew3m6eAGdU4gNZwpZ34NMe4GYswg==
 
 cosmiconfig@7.0.0:
   version "7.0.0"
@@ -1757,6 +1757,11 @@ minimist@^1.2.0:
   resolved "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
 
+mitt@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/mitt/-/mitt-3.0.1.tgz#ea36cf0cc30403601ae074c8f77b7092cdab36d1"
+  integrity sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==
+
 mkdirp@^1.0.4:
   version "1.0.4"
   resolved "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz"
@@ -2013,10 +2018,10 @@ plur@^4.0.0:
   dependencies:
     irregular-plurals "^3.2.0"
 
-prettier@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.0.3.tgz#432a51f7ba422d1469096c0fdc28e235db8f9643"
-  integrity sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==
+prettier@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.1.1.tgz#6ba9f23165d690b6cbdaa88cb0807278f7019848"
+  integrity sha512-22UbSzg8luF4UuZtzgiUOfcGM8s4tjBv6dJRT7j275NXsy2jb4aJa4NNveul5x4eqlF1wuhuR2RElK71RvmVaw==
 
 pretty-format@^29.7.0:
   version "29.7.0"
@@ -2456,10 +2461,10 @@ trim-newlines@^3.0.0:
   resolved "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz"
   integrity sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==
 
-ts-loader@^9.5.0:
-  version "9.5.0"
-  resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-9.5.0.tgz#f0a51dda37cc4d8e43e6cb14edebbc599b0c3aa2"
-  integrity sha512-LLlB/pkB4q9mW2yLdFMnK3dEHbrBjeZTYguaaIfusyojBgAGf5kF+O6KcWqiGzWqHk0LBsoolrp4VftEURhybg==
+ts-loader@^9.5.1:
+  version "9.5.1"
+  resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-9.5.1.tgz#63d5912a86312f1fbe32cef0859fb8b2193d9b89"
+  integrity sha512-rNH3sK9kGZcH9dYzC7CewQm4NtxJTjSEVRJ2DyBZR7f8/wcta+iV44UPCXc5+nzDzivKtlzV6c9P4e+oFhDLYg==
   dependencies:
     chalk "^4.1.0"
     enhanced-resolve "^5.0.0"
@@ -2498,12 +2503,12 @@ ts-node@^9:
     source-map-support "^0.5.17"
     yn "3.1.1"
 
-tsd@^0.29.0:
-  version "0.29.0"
-  resolved "https://registry.npmjs.org/tsd/-/tsd-0.29.0.tgz"
-  integrity sha512-5B7jbTj+XLMg6rb9sXRBGwzv7h8KJlGOkTHxY63eWpZJiQ5vJbXEjL0u7JkIxwi5EsrRE1kRVUWmy6buK/ii8A==
+tsd@^0.30.3:
+  version "0.30.3"
+  resolved "https://registry.yarnpkg.com/tsd/-/tsd-0.30.3.tgz#8dbec4ae313408604db507c22f7f325c664ed234"
+  integrity sha512-xoEp6JPqpT9Ti9wGX5qgy7URp0lrmxN7YkbsyphBzdc1SYiXvJYgRXSIVvSZz42+/Wd/R1kBOMbgGC6rtiKxqQ==
   dependencies:
-    "@tsd/typescript" "~5.2.2"
+    "@tsd/typescript" "~5.3.3"
     eslint-formatter-pretty "^4.1.0"
     globby "^11.0.1"
     jest-diff "^29.0.3"
@@ -2551,10 +2556,10 @@ typescript-memoize@^1.0.0-alpha.3:
   resolved "https://registry.npmjs.org/typescript-memoize/-/typescript-memoize-1.1.1.tgz"
   integrity sha512-GQ90TcKpIH4XxYTI2F98yEQYZgjNMOGPpOgdjIBhaLaWji5HPWlRnZ4AeA1hfBxtY7bCGDJsqDDHk/KaHOl5bA==
 
-typescript@^5.2.2:
-  version "5.2.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.2.2.tgz#5ebb5e5a5b75f085f22bc3f8460fba308310fa78"
-  integrity sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==
+typescript@^5.3.3:
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.3.3.tgz#b3ce6ba258e72e6305ba66f5c9b452aaee3ffe37"
+  integrity sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==
 
 typical@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
# Implement res.on('finish', callback)

Implements the `finish` event, emitted immediately before the final response headers and body are handed off to the Fastly Compute platform to send back to the client.

This is useful for tidying up any post-request actions (e.g. sending logs/metrics/traces).

See https://github.com/fastly/expressly/issues/30 

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.2.2--canary.52.7473191090.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @fastly/expressly@2.2.2--canary.52.7473191090.0
  # or 
  yarn add @fastly/expressly@2.2.2--canary.52.7473191090.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

## Usage

```js
import { Router } from "@fastly/expressly";

const router = new Router();

router.use((_, res) => {
  res.on("finish", (finalResponse) => {
    console.log("Response sent!", finalResponse);
  });
});

router.get("/", (req, res) => {
  return res.send("Home");
});

router.listen();
```
