### PR TITLE
chore: upgrade cookie due to security vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,9 +40,9 @@
   },
   "dependencies": {
     "@fastly/js-compute": "^3.7.0",
-    "cookie": "^0.6.0",
-    "mitt": "^3.0.1",
+    "cookie": "^0.7.0",
     "core-js": "^3.35.0",
+    "mitt": "^3.0.1",
     "path-to-regexp": "^6.2.1"
   },
   "auto": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -960,10 +960,10 @@ concat-map@0.0.1:
   resolved "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
   integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
 
-cookie@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.6.0.tgz#2798b04b071b0ecbff0dbb62a505a8efa4e19051"
-  integrity sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==
+cookie@^0.7.0:
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.7.2.tgz#556369c472a2ba910f2979891b526b3436237ed7"
+  integrity sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==
 
 core-js@^3.35.0:
   version "3.35.0"


### PR DESCRIPTION
There is a security advisory to upgrade `cookie` to at least version 0.7.0: https://github.com/jshttp/cookie/security/advisories/GHSA-pxg6-pf52-xh8x